### PR TITLE
Safely output strings into the package manifest

### DIFF
--- a/x-pack/plugins/integration_assistant/server/integration_builder/build_integration.test.ts
+++ b/x-pack/plugins/integration_assistant/server/integration_builder/build_integration.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { Integration } from '../../common';
+import { configureNunjucks, preparePackageManifest } from './build_integration';
+import yaml from 'js-yaml';
+
+describe('preparePackageManifest', () => {
+  beforeEach(() => {
+    configureNunjucks();
+  });
+
+  test('generates the package manifest correctly', () => {
+    const integration: Integration = {
+      title: 'Sample Integration',
+      name: 'sample-integration',
+      description:
+        '  This is a sample integration\n\nWith multiple lines   and    weird  spacing. \n\n  And more lines  ',
+      logo: 'some-logo.png',
+      dataStreams: [
+        {
+          name: 'data-stream-1',
+          title: 'Data Stream 1',
+          description: 'This is data stream 1',
+          inputTypes: ['filestream'],
+          rawSamples: ['{field: "value"}'],
+          pipeline: {
+            processors: [],
+          },
+          docs: [],
+          samplesFormat: { name: 'ndjson', multiline: false },
+        },
+        {
+          name: 'data-stream-2',
+          title: 'Data Stream 2',
+          description:
+            'This is data stream 2\nWith multiple lines of description\nBut otherwise, nothing special',
+          inputTypes: ['aws-cloudwatch'],
+          pipeline: {
+            processors: [],
+          },
+          rawSamples: ['field="value"'],
+          docs: [],
+          samplesFormat: { name: 'structured' },
+        },
+      ],
+    };
+
+    const manifestContent = preparePackageManifest(integration);
+
+    // Rhe manifest content must be parseable as YAML.
+    const manifest = yaml.safeLoad(manifestContent);
+
+    expect(manifest).toBeDefined();
+    expect(manifest.title).toBe(integration.title);
+    expect(manifest.name).toBe(integration.name);
+    expect(manifest.type).toBe('integration');
+    expect(manifest.description).toBe(integration.description);
+    expect(manifest.icons).toBeTruthy();
+  });
+});

--- a/x-pack/plugins/integration_assistant/server/integration_builder/build_integration.ts
+++ b/x-pack/plugins/integration_assistant/server/integration_builder/build_integration.ts
@@ -9,6 +9,7 @@ import AdmZip from 'adm-zip';
 import nunjucks from 'nunjucks';
 import { getDataPath } from '@kbn/utils';
 import { join as joinPath } from 'path';
+import { safeDump } from 'js-yaml';
 import type { DataStream, Integration } from '../../common';
 import { createSync, ensureDirSync, generateUniqueId, removeDirSync } from '../util';
 import { createAgentInput } from './agent';
@@ -91,7 +92,7 @@ function createBuildFile(packageDir: string): void {
 
 function createChangelog(packageDir: string): void {
   const changelogTemplate = nunjucks.render('changelog.yml.njk', {
-    initial_version: initialVersion,
+    initial_version: safeDump(initialVersion),
   });
 
   createSync(joinPath(packageDir, 'changelog.yml'), changelogTemplate);
@@ -101,7 +102,7 @@ function createReadme(packageDir: string, integration: Integration) {
   const readmeDirPath = joinPath(packageDir, '_dev/build/docs/');
   ensureDirSync(readmeDirPath);
   const readmeTemplate = nunjucks.render('package_readme.md.njk', {
-    package_name: integration.name,
+    package_name: safeDump(integration.name),
     data_streams: integration.dataStreams,
   });
 
@@ -123,9 +124,9 @@ function createPackageManifest(packageDir: string, integration: Integration): vo
     dataStream.inputTypes.forEach((inputType: string) => {
       if (!uniqueInputs[inputType]) {
         uniqueInputs[inputType] = {
-          type: inputType,
-          title: dataStream.title,
-          description: dataStream.description,
+          type: safeDump(inputType),
+          title: safeDump(`${dataStream.title} : ${inputType}`),
+          description: safeDump(dataStream.description),
         };
       }
     });
@@ -135,13 +136,14 @@ function createPackageManifest(packageDir: string, integration: Integration): vo
 
   const packageManifest = nunjucks.render('package_manifest.yml.njk', {
     format_version: '3.1.4',
-    package_title: integration.title,
-    package_name: integration.name,
-    package_version: initialVersion,
-    package_description: integration.description,
-    package_logo: integration.logo,
+    package_title: safeDump(integration.title),
+    package_name: safeDump(integration.name),
+    package_version: safeDump(initialVersion),
+    package_description: safeDump(integration.description),
+    package_logo: safeDump(integration.logo),
+    package_logo_title: safeDump(`${integration.name} Logo`),
     package_owner: '@elastic/custom-integrations',
-    min_version: '^8.13.0',
+    min_version: safeDump('^8.13.0'),
     inputs: uniqueInputsList,
   });
 

--- a/x-pack/plugins/integration_assistant/server/integration_builder/build_integration.ts
+++ b/x-pack/plugins/integration_assistant/server/integration_builder/build_integration.ts
@@ -19,6 +19,10 @@ import { createPipeline } from './pipeline';
 
 const initialVersion = '1.0.0';
 
+function safeDumpString(value: string): string {
+  return safeDump(value, { skipInvalid: true });
+}
+
 export async function buildPackage(integration: Integration): Promise<Buffer> {
   const templateDir = joinPath(__dirname, '../templates');
   const agentTemplates = joinPath(templateDir, 'agent');
@@ -92,7 +96,7 @@ function createBuildFile(packageDir: string): void {
 
 function createChangelog(packageDir: string): void {
   const changelogTemplate = nunjucks.render('changelog.yml.njk', {
-    initial_version: safeDump(initialVersion),
+    initial_version: safeDumpString(initialVersion),
   });
 
   createSync(joinPath(packageDir, 'changelog.yml'), changelogTemplate);
@@ -102,7 +106,7 @@ function createReadme(packageDir: string, integration: Integration) {
   const readmeDirPath = joinPath(packageDir, '_dev/build/docs/');
   ensureDirSync(readmeDirPath);
   const readmeTemplate = nunjucks.render('package_readme.md.njk', {
-    package_name: safeDump(integration.name),
+    package_name: safeDumpString(integration.name),
     data_streams: integration.dataStreams,
   });
 
@@ -124,9 +128,9 @@ function createPackageManifest(packageDir: string, integration: Integration): vo
     dataStream.inputTypes.forEach((inputType: string) => {
       if (!uniqueInputs[inputType]) {
         uniqueInputs[inputType] = {
-          type: safeDump(inputType),
-          title: safeDump(`${dataStream.title} : ${inputType}`),
-          description: safeDump(dataStream.description),
+          type: safeDumpString(inputType),
+          title: safeDumpString(`${dataStream.title} : ${inputType}`),
+          description: safeDumpString(dataStream.description),
         };
       }
     });
@@ -136,14 +140,14 @@ function createPackageManifest(packageDir: string, integration: Integration): vo
 
   const packageManifest = nunjucks.render('package_manifest.yml.njk', {
     format_version: '3.1.4',
-    package_title: safeDump(integration.title),
-    package_name: safeDump(integration.name),
-    package_version: safeDump(initialVersion),
-    package_description: safeDump(integration.description),
-    package_logo: safeDump(integration.logo),
-    package_logo_title: safeDump(`${integration.name} Logo`),
+    package_title: safeDumpString(integration.title),
+    package_name: safeDumpString(integration.name),
+    package_version: safeDumpString(initialVersion),
+    package_description: safeDumpString(integration.description),
+    package_logo: safeDumpString(integration.logo ?? ''),
+    package_logo_title: safeDumpString(`${integration.name} Logo`),
     package_owner: '@elastic/custom-integrations',
-    min_version: safeDump('^8.13.0'),
+    min_version: safeDumpString('^8.13.0'),
     inputs: uniqueInputsList,
   });
 

--- a/x-pack/plugins/integration_assistant/server/templates/manifest/package_manifest.yml.njk
+++ b/x-pack/plugins/integration_assistant/server/templates/manifest/package_manifest.yml.njk
@@ -1,10 +1,8 @@
-format_version: "{{ format_version }}"
-name: "{{ package_name }}"
-title: |
-  {{ package_title }}
+format_version: {{ format_version }}
+name: {{ package_name }}
+title: {{ package_title }}
 version: {{ package_version }}
-description: |
-  {{ package_description }}
+description: {{ package_description }}
 type: integration
 categories:
   - security
@@ -14,21 +12,17 @@ conditions:
     version: {{ min_version }}
 {% if package_logo %}icons:
   - src: /img/logo.svg
-    title: "{{ package_name }} Logo"
+    title: {{ package_logo_title }}
     size: 32x32
     type: image/svg+xml{% endif %}
 policy_templates:
   - name: {{ package_name }}
-    title: |
-      {{ package_title }}
-    description: |
-      {{ package_description}}
+    title: {{ package_title }}
+    description: {{ package_description}}
     inputs: {% for input in inputs %}
       - type: {{ input.type }}
-        title: |
-          {{ input.title }} : {{ input.type }}
-        description: |
-          {{ input.description }} {% endfor %}
+        title: {{ input.title }}
+        description: {{ input.description }} {% endfor %}
 owner:
   github: "{{ package_owner }}"
   type: elastic


### PR DESCRIPTION
## Summary

Previously the multiline output or special symbols in the user-provided strings, like description, were breaking YAML structure of the package manifest. Especially unfortunate was that this was happening during the last step, after all the work of generating the integration was completed.

We implement  a method to safely output a string into a YAML template and apply it to all user-provided strings in the package manifest. As a result, strings are correctly saved. 

The method consists in us using the `safeDump` from `js-yaml` to render the following YAML structure:

```
a:
    b: <user-provided string>
```

and then removing the preamble, keeping only the string. The resulting string will be a correctly formatted YAML string; it will be quoted as necessary, like this:

```yaml
abc
"1.0"
"string \t with \t tabs"
```

For multiline strings, the typical output would rely on the `|` symbol, e.g.

```yaml
|
    multiline
    string
```

When outputting such a string, care needs to be taken: it will work in the context of 

```yaml
key: {{ rendered_string }}
``` 

but it will break in the context of 

```yaml
key: 
  another:
    one_more: 
       yet_another: {{ rendered_string }}
``` 

because it will be rendered as this incorrect YAML:

```yaml
key: 
  another:
    one_more: 
       yet_another: |
    multiline
    string
``` 

Therefore the documentation of `renderYAMLString` notes that it is only safe to use this function in the files that do not have indents in excess of `MaxManifestNestedIndent`. Our package manifest is safe in that regard. 

We add tests to verify the correctness of generated manifests.


### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/main/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] [Flaky Test Runner](https://ci-stats.kibana.dev/trigger_flaky_test_runner/1) was used on any tests changed
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/main/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/main/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
